### PR TITLE
Implement focus search keybinding

### DIFF
--- a/src/main/java/com/latmod/mods/projectex/ProjectEX.java
+++ b/src/main/java/com/latmod/mods/projectex/ProjectEX.java
@@ -74,6 +74,8 @@ public class ProjectEX
 			{
 				ex.printStackTrace();
 			}
+
+			ProjectEXKeyBindings.init();
 		}
 
 		if (ProjectEXConfig.general.blacklist_power_flower_from_watch)

--- a/src/main/java/com/latmod/mods/projectex/ProjectEXKeyBindings.java
+++ b/src/main/java/com/latmod/mods/projectex/ProjectEXKeyBindings.java
@@ -1,0 +1,17 @@
+package com.latmod.mods.projectex;
+
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.client.settings.KeyConflictContext;
+import net.minecraftforge.client.settings.KeyModifier;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import org.lwjgl.input.Keyboard;
+
+public final class ProjectEXKeyBindings
+{
+	public static final KeyBinding FOCUS_SEARCH_BAR = new KeyBinding("key.projectex.focusSearchBar", KeyConflictContext.GUI, Keyboard.KEY_TAB, ProjectEX.MOD_NAME);
+
+	public static void init()
+	{
+		ClientRegistry.registerKeyBinding(FOCUS_SEARCH_BAR);
+	}
+}

--- a/src/main/java/com/latmod/mods/projectex/gui/GuiTableBase.java
+++ b/src/main/java/com/latmod/mods/projectex/gui/GuiTableBase.java
@@ -1,5 +1,6 @@
 package com.latmod.mods.projectex.gui;
 
+import com.latmod.mods.projectex.ProjectEXKeyBindings;
 import com.latmod.mods.projectex.ProjectEXUtils;
 import com.latmod.mods.projectex.client.ProjectEXClientConfig;
 import com.latmod.mods.projectex.integration.jei.ProjectEXJEIIntegration;
@@ -260,7 +261,7 @@ public abstract class GuiTableBase extends GuiContainer implements ContainerTabl
 			return;
 		}
 
-		if (!searchField.isFocused() && (typedChar == '\t' || typedChar == ' '))
+		if (!searchField.isFocused() && ProjectEXKeyBindings.FOCUS_SEARCH_BAR.isActiveAndMatches(keyCode))
 		{
 			searchField.setFocused(true);
 			return;


### PR DESCRIPTION
Hardcoded tab and space values to focus the search box cause issues with existing inventory keybinds. For example, closing the inventory using tab gets overridden by the focus and needs to be pressed twice to actually close (once to focus, another to close). I've added custom keybind functionality to be able to work around these conflicts.

Default keybind is tab.